### PR TITLE
Test the context methods, rather than just `the`.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,9 +50,9 @@ All of your other minitest stuff should work normally. Context
 before/after blocks are executed once for each test, so the randomization built into
 minitest will still work as you'd expect.
 
-`a`, `an`, `and`, `the`, and `that` all define contexts, so you can build
-readable sentences like "_a_ user _that_ has an expired password _and_ a bad email
-address" or "_the_ singleton."
+`a`, `an`, `and_also`, `the`, and `that` all define contexts, so you can build
+readable sentences like "_a_ user _that_ has an expired password _and_also_ a bad
+email address" or "_the_ singleton."
 
 `it` defines tests; `it_eventually` defines tests that are to be skipped.
 

--- a/lib/nutrasuite/contexts.rb
+++ b/lib/nutrasuite/contexts.rb
@@ -20,7 +20,7 @@ module Nutrasuite
     #     ...tests...
     #   end
     #
-    ["a", "an", "and", "that", "the"].each do |article|
+    ["a", "an", "and_also", "that", "the"].each do |article|
       eval <<-HERE
         def #{article}(name, &block)
           name = "#{article} " << name

--- a/test/unit/contexts_test.rb
+++ b/test/unit/contexts_test.rb
@@ -72,19 +72,20 @@ class ContextsTest < Test::Unit::TestCase
     end
   end
 
+  # Note that this isn't calling and as that's a syntax error
   the "'and' context" do
+    it_eventually "works" do
+      assert true
+    end
+  end
+
+  an "'an' context" do
     it "works" do
       assert true
     end
   end
 
-  the "'an' context" do
-    it "works" do
-      assert true
-    end
-  end
-
-  the "'that' context" do
+  that "'that' context" do
     it "works" do
       assert true
     end

--- a/test/unit/contexts_test.rb
+++ b/test/unit/contexts_test.rb
@@ -72,9 +72,8 @@ class ContextsTest < Test::Unit::TestCase
     end
   end
 
-  # Note that this isn't calling and as that's a syntax error
-  the "'and' context" do
-    it_eventually "works" do
+  and_also "'and_also' context" do
+    it "works" do
       assert true
     end
   end


### PR DESCRIPTION
Skipped the test for `and` out as it's a syntax error.
