### PR TITLE
Require test/unit/testcase

### DIFF
--- a/lib/nutrasuite.rb
+++ b/lib/nutrasuite.rb
@@ -1,4 +1,4 @@
-require "test/unit"
+require "test/unit/testcase"
 
 require "nutrasuite/version"
 


### PR DESCRIPTION
Fixes a bug with a test/unit require when running rake tasks.

This was found with similar test suites that included test/unit over
test/unit/testcase. See: https://github.com/thoughtbot/shoulda/issues/223
